### PR TITLE
Be able to define a WSDL

### DIFF
--- a/src/Infrastructure/Services/WebService.php
+++ b/src/Infrastructure/Services/WebService.php
@@ -21,14 +21,18 @@ class WebService
 
 	/**
 	 * ServiceRequest constructor.
+	 * @param Wsdl $wsdl
 	 */
-	public function __construct()
+	public function __construct(Wsdl $wsdl = null)
 	{
+		$wsdl_url = (null == $wsdl) ? null : $wsdl->url();
+
 		$this->service = new WebServiceJP([
-				"compression" => SOAP_COMPRESSION_ACCEPT
-					| SOAP_COMPRESSION_GZIP
-					| SOAP_COMPRESSION_DEFLATE,
-			]
+			"compression" => SOAP_COMPRESSION_ACCEPT
+				| SOAP_COMPRESSION_GZIP
+				| SOAP_COMPRESSION_DEFLATE,
+		],
+			$wsdl_url
 		);
 	}
 

--- a/src/Infrastructure/Services/Wsdl.php
+++ b/src/Infrastructure/Services/Wsdl.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace StayForLong\Juniper\Infrastructure\Services;
+
+
+class Wsdl
+{
+	/** @var string */
+	private $wsdl;
+
+	/**
+	 * Wsdl constructor.
+	 * @param string $wsdl
+	 */
+	public function __construct($wsdl)
+	{
+		$this->wsdl = $wsdl;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function url()
+	{
+		return $this->wsdl;
+	}
+
+}


### PR DESCRIPTION
Right now is not possible to define a custom WSDL URL and http://xml2.bookingengine.es/WebService/JP/WebServiceJP.asmx?WSDL is hardcoded.

This PR allows to define a WSDL URL on the creation of the Juniper Web Service, **keeping backwards compatibility**.

I didn't want to modify the WebServiceJP file, since it seems to be automatically generated.