### PR TITLE
Add support for cancellation policies on BookingRules

### DIFF
--- a/src/Application/Hotel/BookingRules.php
+++ b/src/Application/Hotel/BookingRules.php
@@ -2,6 +2,7 @@
 
 namespace StayForLong\Juniper\Application\Hotel;
 
+
 use Juniper\Webservice\ArrayOfJP_RelPax;
 use Juniper\Webservice\ArrayOfString5;
 use Juniper\Webservice\HotelBookingRules;
@@ -17,12 +18,13 @@ use Juniper\Webservice\JP_RelPax;
 use Juniper\Webservice\JP_RelPaxesDist;
 use Juniper\Webservice\JP_SearchSegmentHotels;
 use Juniper\Webservice\JP_SearchSegmentsHotels;
-use StayForLong\Juniper\Domain\Hotel\Rate;
+use StayForLong\Juniper\Domain\Hotel\BookingRules as BookingRulesValueObject;
 use StayForLong\Juniper\Domain\Hotel\Country;
 use StayForLong\Juniper\Domain\Hotel\Nights;
+use StayForLong\Juniper\Domain\Hotel\Rate;
 use StayForLong\Juniper\Infrastructure\Services\JuniperWebService;
 use StayForLong\Juniper\Infrastructure\Services\WebService;
-use StayForLong\Juniper\Domain\Hotel\BookingRules as BookingRulesValueObject;
+use StayForLong\Juniper\Infrastructure\Transformer\BookingRulesTransformer;
 
 /**
  * Class BookingRules
@@ -60,7 +62,7 @@ class BookingRules
 	 */
 	public function __invoke(Rate $rate, $hotel_code, $reference, array $comments = [])
 	{
-		$hotels_code          = [$hotel_code];
+		$hotels_code = [$hotel_code];
 
 		$arrayOfString        = new ArrayOfString5();
 		$hotelCodes           = $arrayOfString->setHotelCode($hotels_code);
@@ -114,9 +116,13 @@ class BookingRules
 			 */
 			$optionBookingRules = $resultsBookingRule->getHotelOptions()->getHotelOption();
 			foreach ($optionBookingRules as $bookingRules) {
-				$BookingRules          = new BookingRulesValueObject($bookingRules, $hotels_code, $reference,
+				$bookingRulesTransformer = new BookingRulesTransformer(
+					$bookingRules,
+					$hotel_code,
+					$reference,
 					$comments);
-				$optionsBookingRules[] = $BookingRules;
+				$BookingRules            = $bookingRulesTransformer->transform();
+				$optionsBookingRules[]   = $BookingRules;
 			}
 		}
 

--- a/src/Domain/Hotel/BookingRules.php
+++ b/src/Domain/Hotel/BookingRules.php
@@ -3,7 +3,6 @@
 namespace StayForLong\Juniper\Domain\Hotel;
 
 use Juniper\Webservice\JP_BookingCode;
-use Juniper\Webservice\JP_HotelOptionBookingRules;
 
 class BookingRules
 {
@@ -42,27 +41,20 @@ class BookingRules
 	 */
 	private $currency;
 
+	/** @var array */
+	private $cancellationPolicies;
+
 	/**
 	 * BookingRules constructor.
-	 * @param JP_HotelOptionBookingRules $bookingRules
+	 * @param JP_BookingCode $code
 	 * @param string $hotel_code
 	 * @param string $reference
-	 * @param array $comments
 	 */
-	public function __construct(JP_HotelOptionBookingRules $bookingRules, $hotel_code, $reference, array $comments = [])
+	public function __construct(JP_BookingCode $code, $hotel_code, $reference)
 	{
-		$this->bookingCode = new JP_BookingCode($bookingRules->getBookingCode()->get_(),
-			$bookingRules->getBookingCode()->getExpirationDate());
-
-		$this->hotel_code = $hotel_code;
-		$this->reference  = $reference;
-		$this->comments   = $comments;
-
-		$prices           = $bookingRules->getPriceInformation()->getPrices();
-		$number_of_prices = $bookingRules->getPriceInformation()->getPrices()->count();
-		$this->currency   = $prices[0]->getCurrency();
-		$this->min_price  = $prices[0]->getTotalFixAmounts()->getNett();
-		$this->max_price  = $prices[$number_of_prices-1]->getTotalFixAmounts()->getNett();
+		$this->bookingCode = $code;
+		$this->hotel_code  = $hotel_code;
+		$this->reference   = $reference;
 	}
 
 	/**
@@ -120,4 +112,63 @@ class BookingRules
 	{
 		return $this->currency;
 	}
+
+	/**
+	 * @param array $comments
+	 * @return $this
+	 */
+	public function setComments(array $comments)
+	{
+		$this->comments = $comments;
+		return $this;
+	}
+
+	/**
+	 * @param float $min_price
+	 * @return $this
+	 */
+	public function setMinPrice(float $min_price)
+	{
+		$this->min_price = $min_price;
+		return $this;
+	}
+
+	/**
+	 * @param float $max_price
+	 * @return $this
+	 */
+	public function setMaxPrice(float $max_price)
+	{
+		$this->max_pice = $max_price;
+		return $this;
+	}
+
+	/**
+	 * @param string $currency
+	 * @return $this
+	 */
+	public function setCurrency(string $currency)
+	{
+		$this->currency = $currency;
+		return $this;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function cancellationPolicies()
+	{
+		return $this->cancellationPolicies;
+	}
+
+	/**
+	 * @param array $cancellationPolicies
+	 * @return $this
+	 */
+	public function setCancellationPolicies(array $cancellationPolicies)
+	{
+		$this->cancellationPolicies = $cancellationPolicies;
+		return $this;
+	}
+
 }

--- a/src/Domain/Hotel/CancellationPolicy.php
+++ b/src/Domain/Hotel/CancellationPolicy.php
@@ -1,0 +1,70 @@
+<?php
+
+
+namespace StayForLong\Juniper\Domain\Hotel;
+
+
+use Carbon\Carbon;
+
+class CancellationPolicy
+{
+	/** @var Carbon */
+	private $dateFrom;
+
+	/** @var Carbon */
+	private $dateTo;
+
+	/** @var float */
+	private $fixedPrice;
+
+	/** @var float */
+	private $percentPrice;
+
+	/**
+	 * CancellationPolicy constructor.
+	 * @param Carbon $dateFrom
+	 * @param Carbon $dateTo
+	 * @param float $fixedPrice
+	 * @param float $percentPrice
+	 */
+	public function __construct(Carbon $dateFrom, Carbon $dateTo, $fixedPrice, $percentPrice)
+	{
+		$this->dateFrom     = $dateFrom;
+		$this->dateTo       = $dateTo;
+		$this->fixedPrice   = $fixedPrice;
+		$this->percentPrice = $percentPrice;
+	}
+
+	/**
+	 * @return Carbon
+	 */
+	public function dateFrom(): Carbon
+	{
+		return $this->dateFrom;
+	}
+
+	/**
+	 * @return Carbon
+	 */
+	public function dateTo(): Carbon
+	{
+		return $this->dateTo;
+	}
+
+	/**
+	 * @return float
+	 */
+	public function fixedPrice()
+	{
+		return $this->fixedPrice;
+	}
+
+	/**
+	 * @return float
+	 */
+	public function percentPrice()
+	{
+		return $this->percentPrice;
+	}
+	
+}

--- a/src/Infrastructure/Transformer/BookingRulesTransformer.php
+++ b/src/Infrastructure/Transformer/BookingRulesTransformer.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace StayForLong\Juniper\Infrastructure\Transformer;
+
+
+use Carbon\Carbon;
+use Juniper\Webservice\JP_BookingCode;
+use Juniper\Webservice\JP_HotelOptionBookingRules;
+use StayForLong\Juniper\Domain\Hotel\BookingRules;
+use StayForLong\Juniper\Domain\Hotel\CancellationPolicy;
+
+class BookingRulesTransformer
+{
+	/** @var JP_HotelOptionBookingRules */
+	private $bookingRules;
+	/** @var string */
+	private $hotel_code;
+	/** @var string */
+	private $reference;
+	/** @var array */
+	private $comments;
+
+	/**
+	 * BookingRulesTransformer constructor.
+	 * @param JP_HotelOptionBookingRules $bookingRules
+	 * @param string $hotel_code
+	 * @param string $reference
+	 * @param array $comments
+	 */
+	public function __construct(
+		JP_HotelOptionBookingRules $bookingRules,
+		$hotel_code,
+		$reference,
+		$comments = []
+	) {
+		$this->bookingRules = $bookingRules;
+		$this->hotel_code   = $hotel_code;
+		$this->reference    = $reference;
+		$this->comments     = $comments;
+	}
+
+	/**
+	 * @return BookingRules
+	 */
+	public function transform()
+	{
+		$expirationDate = Carbon::instance($this->bookingRules->getBookingCode()->getExpirationDate());
+
+		$prices       = $this->bookingRules->getPriceInformation()->getPrices();
+		$prices_count = $this->bookingRules->getPriceInformation()->getPrices()->count();
+
+
+		$bookingCode = new JP_BookingCode(
+			$this->bookingRules->getBookingCode()->get_(),
+			$this->bookingRules->getBookingCode()->getExpirationDate()
+		);
+
+		$cancellationPolicies = [];
+		foreach ($this->bookingRules->getCancellationPolicy()->getPolicyRules() as $cancellationPolicy) {
+			$cancellationPolicies[] = new CancellationPolicy(
+				Carbon::parse($cancellationPolicy->getDateFrom() . " " . $cancellationPolicy->getDateFromHour()),
+				Carbon::parse($cancellationPolicy->getDateTo() . " " . $cancellationPolicy->getDateToHour()),
+				$cancellationPolicy->getFixedPrice(),
+				$cancellationPolicy->getPercentPrice()
+			);
+		}
+
+		return (new BookingRules(
+			$bookingCode,
+			$expirationDate,
+			$this->hotel_code,
+			$this->reference))
+			->setComments($this->comments)
+			->setCurrency($prices->current()->getCurrency())
+			->setMinPrice($prices->current()->getTotalFixAmounts()->getNett())
+			->setMaxPrice($prices[$prices_count - 1]->getTotalFixAmounts()->getNett())
+			->setCancellationPolicies($cancellationPolicies);
+	}
+}


### PR DESCRIPTION
Leave the BookingRule object 'as is' adding cancellation additional cancellation policies.

The object BookingRule can only be extended, since its used on the booking process.